### PR TITLE
Update binder badge URL

### DIFF
--- a/R/badge.R
+++ b/R/badge.R
@@ -116,7 +116,7 @@ stages <- c(
 use_binder_badge <- function() {
   if (uses_github()) {
     url <- glue("https://mybinder.org/v2/gh/{github_repo_spec()}/master")
-    img <- "http://mybinder.org/badge.svg"
+    img <- "https://mybinder.org/badge_logo.svg"
     use_badge("Launch binder", url, img)
   }
 


### PR DESCRIPTION
Binder has a new badge now with a logo, see https://discourse.jupyter.org/t/help-us-choose-an-updated-launch-binder-badge/100/21

Also changed the protocol to `https`, to which `http` is redirected.